### PR TITLE
Add additional configuration for Design Studio

### DIFF
--- a/dx.yaml
+++ b/dx.yaml
@@ -105,6 +105,7 @@ services:
       - PORTAL_PORT=10039 
       - PORTAL_HOST=core
       - EXTERNAL_RING_API_HOST=${DX_HOSTNAME:?'Please set hostname'}
+      - WCMREST_API_HOST=${DX_HOSTNAME:?'Please set hostname'}
       - EXTERNAL_RING_API_PORT=4000
       - RING_API_HOST=ringapi
       - RING_API_PORT=3000


### PR DESCRIPTION
Just adding additional configuration to get Design Studio image to function within docker-compose.  Without it, Design Studio will not load, errors will be seen in the network tab.