### PR TITLE
Fix DB node restart issue for CF 220 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ load.bat <docker-image-archives-directory>
 
 ### Set up local environment variables
 
+If the docker compose is not running on local, then DX_HOSTNAME value in set.sh/set.bat needs to be modified accordingly.
+
 Linux/MAC:
 
 ```bash

--- a/dx.yaml
+++ b/dx.yaml
@@ -112,7 +112,8 @@ services:
       - REPMGR_PORT_NUMBER=5432
       - REPMGR_PARTNER_NODES=dx-dam-db-node-0;
       - SYNCHRONOUS_COMMIT=off
-      - SYNCHRONOUS_STANDBY_NAMES="*"
+      # The synchronous standby names value should be updated to "1 (*)" if the number of DB nodes is 2
+      - SYNCHRONOUS_STANDBY_NAMES=
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 30s


### PR DESCRIPTION
Update synchronous standby name to empty if node is 1. If there are 2 nodes, then the value needs to be 1 (*)