### PR TITLE
Feature - Load Images from HCL Harbor

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,15 +493,15 @@ The **ssl** folder contains a localhost.pem file that can be used with the hapro
 
 ## Instructions to load HCL DX Container images from HCL Harbor
 
-It is possible to load **the latest** HCL DX-Docker-Compose container images from [HCL Harbor](https://hclcr.io/account/sign-in) using the **loadFromHarbor.bat** (for Microsoft Windows) or **loadFraomHarboer.sh** script for running on Apple Macintosh or any Unix/Linux environment.  
+It is possible to load **the latest** HCL DX-Docker-Compose container images from [HCL Harbor](https://hclcr.io/account/sign-in) using the **loadFromHarbor.bat** (for Microsoft Windows) or **loadFromHarbor.sh** script when running on Apple Macintosh or any Unix/Linux environment.  
 
-#### Tool Prerequisites
+### Harbor Prerequisites
 
-To get that script working correctly it requires to download and install the jq-parser. (**jq-windows-amd64.exe** for Microsoft Windows or **jq** for Mac and Linux from the web-page [Download jq](https://jqlang.org/download/). The jq-windows-amd64.exe file needs to be added to your Windows user environment variable path settings and/or located inside of this git-repository to run that loadFromHarbor.bat script correctly. The script require the HCL Harbor **user-id** and **CLI secrete** to get the container images downloaded and pulled to your docker runtime.  
+To get that scripts working correctly it requires to download and install the jq-parser (**jq-windows-amd64.exe** for Microsoft Windows or **jq** for Apple Macintosh and Unix/Linux environments) from the web-page [Download jq](https://jqlang.org/download/). That additional tool will be used to extract the image-tags. The jq-windows-amd64.exe file needs to be added to your Windows user environment variable path settings and/or located inside of this git-repository to run that loadFromHarbor.bat script correctly. The script requires the HCL Harbor **user-id** and **CLI secrete** to get the container images downloaded and pulled to your local docker runtime.  
 
 **Note:** The scripts will also automatically update your dx.properties file to match the latest container image-tags.
 
-General usage:
+### General usage
 
 1. Ensure that the dx.properties file just contain the variable-names and **no values** of it.
 For example:
@@ -516,12 +516,12 @@ For example:
     DX_DOCKER_IMAGE_HAPROXY=
     DX_DOCKER_IMAGE_PREREQS_CHECKER=
 
-2. start the **loadFromHarbor.bat** or **./loadFromHarbor.sh** script
+2. start the **loadFromHarbor.bat** or **./loadFromHarbor.sh** script.
 
 3. Enter your HCL Harbor **user-id** and **CLI secrete**.
    The HCL DX container-images then should be automatically pulled to your local docker-registry.
 
-4. Run the `set.bat`or `./set.sh` script.
+4. Run the `set.bat`or `set.sh` script to set the environment variables.
 
 5. start the environment with the following command:  
 

--- a/README.md
+++ b/README.md
@@ -490,3 +490,48 @@ The **ssl** folder contains a localhost.pem file that can be used with the hapro
       ```
 
 6. Restart the dx-core container  
+
+## Instructions to load HCL DX Container images from HCL Harbor
+
+### Microsoft Windows
+
+It is possible to load **the latest** HCL DX-Docker-Compose container images from [HCL Harbor](https://hclcr.io/account/sign-in) using the **loadFromHarbor.bat** script.  
+
+#### Tool Prerequisites
+
+To get that script working correctly it requires to download and install **jq-windows-amd64.exe** from the web-page [Download jq](https://jqlang.org/download/).
+The jq-windows-amd64.exe file needs to be added to your Windows user environment variable path settings and/or located inside of this git-repository to run that loadFromHarbor.bat script correctly. The script require the HCL Harbor **user-id** and **CLI secrete** to get the container images downloaded and pulled to your docker runtime.  
+
+**Note:** The script will also automatically update your dx.properties file to match the latest container image-tags.
+
+General usage:
+
+1. Ensure that the dx.properties file just contain the variable-names and **no values** of it.
+For example:
+
+    DX_DOCKER_IMAGE_CONTENT_COMPOSER=
+    DX_DOCKER_IMAGE_CORE=
+    DX_DOCKER_IMAGE_DIGITAL_ASSET_MANAGER=
+    DX_DOCKER_IMAGE_DATABASE_NODE_DIGITAL_ASSET_MANAGER=
+    DX_DOCKER_IMAGE_DATABASE_CONNECTION_POOL_DIGITAL_ASSET_MANAGER=
+    DX_DOCKER_IMAGE_IMAGE_PROCESSOR=
+    DX_DOCKER_IMAGE_RING_API=
+    DX_DOCKER_IMAGE_HAPROXY=
+    DX_DOCKER_IMAGE_PREREQS_CHECKER=
+
+2. start the **loadFromHarbor.bat** script
+
+3. Enter your HCL Harbor **user-id** and **CLI secrete**.
+   The HCL DX container-images then should be automatically pulled to your local docker-registry.
+
+4. Run the `set.bat` script.
+
+5. start the environment with the following command:  
+
+    ```bash
+    docker-compose up -d
+    ```
+
+## Linux / Unix
+
+The script is not present yet. It might be added in the future. Stay tuned.  

--- a/README.md
+++ b/README.md
@@ -493,16 +493,13 @@ The **ssl** folder contains a localhost.pem file that can be used with the hapro
 
 ## Instructions to load HCL DX Container images from HCL Harbor
 
-### Microsoft Windows
-
-It is possible to load **the latest** HCL DX-Docker-Compose container images from [HCL Harbor](https://hclcr.io/account/sign-in) using the **loadFromHarbor.bat** script.  
+It is possible to load **the latest** HCL DX-Docker-Compose container images from [HCL Harbor](https://hclcr.io/account/sign-in) using the **loadFromHarbor.bat** (for Microsoft Windows) or **loadFraomHarboer.sh** script for running on Apple Macintosh or any Unix/Linux environment.  
 
 #### Tool Prerequisites
 
-To get that script working correctly it requires to download and install **jq-windows-amd64.exe** from the web-page [Download jq](https://jqlang.org/download/).
-The jq-windows-amd64.exe file needs to be added to your Windows user environment variable path settings and/or located inside of this git-repository to run that loadFromHarbor.bat script correctly. The script require the HCL Harbor **user-id** and **CLI secrete** to get the container images downloaded and pulled to your docker runtime.  
+To get that script working correctly it requires to download and install the jq-parser. (**jq-windows-amd64.exe** for Microsoft Windows or **jq** for Mac and Linux from the web-page [Download jq](https://jqlang.org/download/). The jq-windows-amd64.exe file needs to be added to your Windows user environment variable path settings and/or located inside of this git-repository to run that loadFromHarbor.bat script correctly. The script require the HCL Harbor **user-id** and **CLI secrete** to get the container images downloaded and pulled to your docker runtime.  
 
-**Note:** The script will also automatically update your dx.properties file to match the latest container image-tags.
+**Note:** The scripts will also automatically update your dx.properties file to match the latest container image-tags.
 
 General usage:
 
@@ -519,19 +516,16 @@ For example:
     DX_DOCKER_IMAGE_HAPROXY=
     DX_DOCKER_IMAGE_PREREQS_CHECKER=
 
-2. start the **loadFromHarbor.bat** script
+2. start the **loadFromHarbor.bat** or **./loadFromHarbor.sh** script
 
 3. Enter your HCL Harbor **user-id** and **CLI secrete**.
    The HCL DX container-images then should be automatically pulled to your local docker-registry.
 
-4. Run the `set.bat` script.
+4. Run the `set.bat`or `./set.sh` script.
 
 5. start the environment with the following command:  
 
     ```bash
     docker-compose up -d
     ```
-
-## Linux / Unix
-
-The script is not present yet. It might be added in the future. Stay tuned.  
+  

--- a/dx.yaml
+++ b/dx.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021, 2023 HCL Technologies
+# Copyright 2021, 2026 HCL Technologies
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dx.yaml
+++ b/dx.yaml
@@ -116,7 +116,7 @@ services:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 60s
       timeout: 360s
-      retries: 3
+      retries: 5
     ports:
       - "5433:5432"
     # It is noticed on Microsoft Windows that the persistence of the postgress DB data may cause performance issues during the first container startup. 

--- a/loadFromHarbor.bat
+++ b/loadFromHarbor.bat
@@ -1,4 +1,4 @@
-:: Copyright 2021, 2023 HCL Technologies
+:: Copyright 2026 HCL Technologies
 ::
 :: Licensed under the Apache License, Version 2.0 (the "License");
 :: you may not use this file except in compliance with the License.

--- a/loadFromHarbor.bat
+++ b/loadFromHarbor.bat
@@ -1,3 +1,17 @@
+:: Copyright 2021, 2023 HCL Technologies
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::     http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+
 @echo off
 echo Download HCL DX container images from HCL Harbor...
 echo Please enter your HCL Harbor login username/id:

--- a/loadFromHarbor.bat
+++ b/loadFromHarbor.bat
@@ -1,0 +1,77 @@
+@echo off
+echo Please enter your HCL Harbor login username/id:
+set /p inputUsername=
+echo Please enter your HCL Harbor CLI secrete:
+set /p inputPassword=
+call helm registry login -u %inputUsername% -p %inputPassword% https://hclcr.io/
+echo Creating harbor directory, if it does not exist...
+if not exist ./harbor md harbor
+echo ------------------------------------------------
+:: Configure here all containers that need to be pulled.
+call:GetContainerFromHCLHarbor dx core DX_DOCKER_IMAGE_CORE
+call:GetContainerFromHCLHarbor dx ringapi DX_DOCKER_IMAGE_RING_API
+call:GetContainerFromHCLHarbor dx digital-asset-manager DX_DOCKER_IMAGE_DIGITAL_ASSET_MANAGER
+call:GetContainerFromHCLHarbor dx image-processor DX_DOCKER_IMAGE_IMAGE_PROCESSOR
+call:GetContainerFromHCLHarbor dx content-composer DX_DOCKER_IMAGE_CONTENT_COMPOSER
+call:GetContainerFromHCLHarbor dx persistence-node DX_DOCKER_IMAGE_DATABASE_NODE_DIGITAL_ASSET_MANAGER
+call:GetContainerFromHCLHarbor dx persistence-connection-pool DX_DOCKER_IMAGE_DATABASE_CONNECTION_POOL_DIGITAL_ASSET_MANAGER
+call:GetContainerFromHCLHarbor dx haproxy DX_DOCKER_IMAGE_HAPROXY
+call:GetContainerFromHCLHarbor dx prereqs-checker DX_DOCKER_IMAGE_PREREQS_CHECKER
+call:setPropertiesFile 
+
+:GetContainerFromHCLHarbor
+if "%1" NEQ "" (
+    if "%2" NEQ "" ( 
+        if "%3" NEQ "" ( goto getFromHCLHarbor %1 %2 %3 )))
+EXIT /B 0
+
+:getFromHCLHarbor
+echo Processing %1-%2 container...
+echo Finding %1-%2-tags on https://hclcr.io...
+curl "https://hclcr.io/api/v2.0/projects/%1/repositories/%2/artifacts?page=1&page_size=10&with_tag=true" -s -u "%inputUsername%:%inputPassword%" -H "Accept: application/json" -H "Content-type: application/json" > ./harbor/harbor_result.json
+echo Extract tags using jq-windows-amd64.exe (need to be downloaded from URL https://jqlang.org/)...
+jq-windows-amd64.exe -r ".[] .tags .[] .name" ./harbor/harbor_result.json > ./harbor/%1-%2-tags.txt
+set "tags="
+for /F "delims=" %%i in (./harbor/%1-%2-tags.txt) do if not defined tags set tags=%%i
+echo Pulling images...
+docker pull hclcr.io/%1/%2:%tags%
+echo Pulling %1-%2 container finished.
+echo Cleanup temp files...
+cd harbor
+del "harbor_result.json"
+cd ..
+echo cleanup finished.
+set arg1=%3
+set arg2=hclcr.io/dx/%2:%tags%
+echo Set variable: %arg1%=%arg2%
+set "%arg1%=%arg2%"
+echo ------------------------------------------------
+EXIT /B 0
+
+:setPropertiesFile 
+echo Updating properties file with image tags...
+(for /f "tokens=1* delims==" %%m in (dx.properties) do (
+IF %%m==DX_DOCKER_IMAGE_CONTENT_COMPOSER  (
+    IF %DX_DOCKER_IMAGE_CONTENT_COMPOSER%=="" ( echo %%m=%%n) ELSE ( echo %%m=%DX_DOCKER_IMAGE_CONTENT_COMPOSER%)
+) ELSE IF %%m==DX_DOCKER_IMAGE_IMAGE_PROCESSOR (
+    IF %DX_DOCKER_IMAGE_IMAGE_PROCESSOR%=="" ( echo %%m=%%n) ELSE ( echo %%m=%DX_DOCKER_IMAGE_IMAGE_PROCESSOR%)
+) ELSE IF %%m==DX_DOCKER_IMAGE_DATABASE_NODE_DIGITAL_ASSET_MANAGER (
+    IF %DX_DOCKER_IMAGE_DATABASE_NODE_DIGITAL_ASSET_MANAGER%=="" ( echo %%m=%%n) ELSE ( echo %%m=%DX_DOCKER_IMAGE_DATABASE_NODE_DIGITAL_ASSET_MANAGER%)
+) ELSE IF %%m==DX_DOCKER_IMAGE_DATABASE_CONNECTION_POOL_DIGITAL_ASSET_MANAGER (
+    IF %DX_DOCKER_IMAGE_DATABASE_CONNECTION_POOL_DIGITAL_ASSET_MANAGER%=="" ( echo %%m=%%n) ELSE ( echo %%m=%DX_DOCKER_IMAGE_DATABASE_CONNECTION_POOL_DIGITAL_ASSET_MANAGER%)
+) ELSE IF %%m==DX_DOCKER_IMAGE_DIGITAL_ASSET_MANAGER (
+    IF %DX_DOCKER_IMAGE_DIGITAL_ASSET_MANAGER%=="" ( echo %%m=%%n) ELSE ( echo %%m=%DX_DOCKER_IMAGE_DIGITAL_ASSET_MANAGER%)
+) ELSE IF %%m==DX_DOCKER_IMAGE_RING_API (
+    IF %DX_DOCKER_IMAGE_RING_API%=="" ( echo %%m=%%n) ELSE ( echo %%m=%DX_DOCKER_IMAGE_RING_API%)
+) ELSE IF %%m==DX_DOCKER_IMAGE_CORE (
+    IF %DX_DOCKER_IMAGE_CORE%=="" ( echo %%m=%%n) ELSE ( echo %%m=%DX_DOCKER_IMAGE_CORE%)
+) ELSE IF %%m==DX_DOCKER_IMAGE_HAPROXY (
+    IF %DX_DOCKER_IMAGE_HAPROXY%=="" ( echo %%m=%%n) ELSE ( echo %%m=%DX_DOCKER_IMAGE_HAPROXY%)
+) ELSE IF %%m==DX_DOCKER_IMAGE_PREREQS_CHECKER (
+    IF %DX_DOCKER_IMAGE_PREREQS_CHECKER%=="" ( echo %%m=%%n) ELSE ( echo %%m=%DX_DOCKER_IMAGE_PREREQS_CHECKER%)
+) else ( echo %%m)
+))>result.properties
+DEL dx.properties
+rename result.properties dx.properties
+echo Task completed.
+EXIT /B 0

--- a/loadFromHarbor.bat
+++ b/loadFromHarbor.bat
@@ -1,9 +1,11 @@
 @echo off
+echo Download HCL DX container images from HCL Harbor...
 echo Please enter your HCL Harbor login username/id:
 set /p inputUsername=
 echo Please enter your HCL Harbor CLI secrete:
 set /p inputPassword=
-call helm registry login -u %inputUsername% -p %inputPassword% https://hclcr.io/
+echo Logging in into HCL Harbor...
+call docker login --username %inputUsername% --password %inputPassword% https://hclcr.io/
 echo Creating harbor directory, if it does not exist...
 if not exist ./harbor md harbor
 echo ------------------------------------------------

--- a/loadFromHarbor.sh
+++ b/loadFromHarbor.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+function updateProperties () 
+{
+    searchValue=$1
+    replaceValue="$1=$arg2"
+    pathValue=$3
+    strSearchAndReplace="s/${searchValue}.*/${replaceValue//\//\\/}/"
+    sed -i.bck "${strSearchAndReplace}" ${pathValue}/dx.properties
+} 
+
+function getFromHCLHarbor () {
+echo Processing $1-$2 container...
+echo Finding $1-$2-tags on https://hclcr.io...
+curl "https://hclcr.io/api/v2.0/projects/$1/repositories/$2/artifacts?page=1&page_size=10&with_tag=true" -s -u "$inputUsername:$inputPassword" -H "Accept: application/json" -H "Content-type: application/json" > ./harbor/harbor_result.json
+echo "Extract tags using jq (need to be downloaded from URL https://jqlang.org/)..."
+jq -r ".[] .tags .[] .name" ./harbor/harbor_result.json > ./harbor/$1-$2-tags.txt
+tags=$(head -n 1 ./harbor/$1-$2-tags.txt)
+echo Pulling images...
+echo "docker pull hclcr.io/$1/$2:$tags"
+docker pull hclcr.io/$1/$2:$tags
+echo Pulling $1-$2 container finished.
+echo Cleanup temp files...
+rm ./harbor/harbor_result.json
+echo cleanup finished.
+arg1=$3
+arg2="hclcr.io/dx/$2:$tags"
+echo Updating the dx.properties...
+updateProperties $3 $arg1 .
+echo ------------------------------------------------
+}
+
+echo Download HCL DX container images from HCL Harbor...
+read -p "Please enter your HCL Harbor login username/id: " inputUsername
+read -s -p "Please enter your HCL Harbor CLI secrete: " inputPassword
+echo Logging in into HCL Harbor...
+docker login --username $inputUsername --password $inputPassword hclcr.io
+echo Creating harbor directory, if it does not exist...
+if [ ! -d "./harbor" ]; then  
+  mkdir harbor
+fi
+
+getFromHCLHarbor dx core DX_DOCKER_IMAGE_CORE
+getFromHCLHarbor dx ringapi DX_DOCKER_IMAGE_RING_API
+getFromHCLHarbor dx digital-asset-manager DX_DOCKER_IMAGE_DIGITAL_ASSET_MANAGER
+getFromHCLHarbor dx image-processor DX_DOCKER_IMAGE_IMAGE_PROCESSOR
+getFromHCLHarbor dx content-composer DX_DOCKER_IMAGE_CONTENT_COMPOSER
+getFromHCLHarbor dx persistence-node DX_DOCKER_IMAGE_DATABASE_NODE_DIGITAL_ASSET_MANAGER
+getFromHCLHarbor dx persistence-connection-pool DX_DOCKER_IMAGE_DATABASE_CONNECTION_POOL_DIGITAL_ASSET_MANAGER
+getFromHCLHarbor dx haproxy DX_DOCKER_IMAGE_HAPROXY
+getFromHCLHarbor dx prereqs-checker DX_DOCKER_IMAGE_PREREQS_CHECKER
+echo Task completed.

--- a/loadFromHarbor.sh
+++ b/loadFromHarbor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021, 2023 HCL Technologies
+# Copyright 2026 HCL Technologies
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/loadFromHarbor.sh
+++ b/loadFromHarbor.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Copyright 2021, 2023 HCL Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 function updateProperties () 
 {
     searchValue=$1


### PR DESCRIPTION
- added a new loadFromHarbor.bat script for windows users to load HCL DX images from HCL Harbor
- added more retries on the persistence-node-0 container to ensure a clean startup (the retry limit of 3 still sometimes lead to startup issues with the probes.)